### PR TITLE
test: temporarily remove first time contributor constraint

### DIFF
--- a/.github/workflows/welcome_new_contributor.yml
+++ b/.github/workflows/welcome_new_contributor.yml
@@ -32,7 +32,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const isFirstContribution = '${{ steps.contributor.outputs.is_first_contribution }}' === 'FIRST_TIME_CONTRIBUTOR';
+            #const isFirstContribution = '${{ steps.contributor.outputs.is_first_contribution }}' === 'FIRST_TIME_CONTRIBUTOR';
+            const isFirstContribution = true
             
             if (isFirstContribution) {
               github.rest.issues.addLabels({
@@ -48,7 +49,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const isFirstContribution = '${{ steps.contributor.outputs.is_first_contribution }}' === 'FIRST_TIME_CONTRIBUTOR';
+            #const isFirstContribution = '${{ steps.contributor.outputs.is_first_contribution }}' === 'FIRST_TIME_CONTRIBUTOR';
+            const isFirstContribution = true
             
             if (isFirstContribution) {
               github.rest.issues.createComment({
@@ -64,7 +66,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const isFirstContribution = '${{ steps.contributor.outputs.is_first_contribution }}' === 'FIRST_TIME_CONTRIBUTOR';
+            #const isFirstContribution = '${{ steps.contributor.outputs.is_first_contribution }}' === 'FIRST_TIME_CONTRIBUTOR';
+            const isFirstContribution = true
             
             if (isFirstContribution) {
               github.rest.issues.addLabels({


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
